### PR TITLE
修复配置加载依赖工作目录，导致 go test ./... 无法运行

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1,0 +1,84 @@
+// Package bootstrap loads the application configuration before any other
+// package reads it.
+//
+// beego's core/config package initialises its global instance from the
+// relative path "conf/app.conf" (see core/config/ini.go). That only resolves
+// when the process runs from the project root. Running "go test ./..." starts
+// each test binary in its own package directory, so the lookup fails and the
+// global instance ends up holding a nil container. Every later config read
+// then dereferences a nil pointer and panics during package initialisation.
+//
+// Packages that read configuration from package-level variables or from init
+// functions blank import this package to guarantee the global instance is
+// ready first:
+//
+//	import _ "go_binance_futures/bootstrap"
+package bootstrap
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/beego/beego/v2/core/config"
+)
+
+// configCandidates are probed in order inside every directory visited while
+// walking up from the working directory. app.conf is gitignored, so
+// app.conf.example is accepted as a fallback to keep a fresh clone testable.
+var configCandidates = []string{
+	filepath.Join("conf", "app.conf"),
+	filepath.Join("conf", "app.conf.example"),
+}
+
+var (
+	projectRootOnce sync.Once
+	projectRootPath string
+)
+
+func init() {
+	if path, ok := findConfigFile(); ok {
+		// Reloading a file beego already parsed is harmless, so the behaviour
+		// stays identical when the process does run from the project root.
+		_ = config.InitGlobalInstance("ini", path)
+	}
+}
+
+// ProjectRoot returns the directory that contains the conf folder, falling
+// back to the working directory when it cannot be located. Use it to resolve
+// bundled resources such as lang files so they do not depend on the working
+// directory either.
+func ProjectRoot() string {
+	projectRootOnce.Do(func() {
+		if path, ok := findConfigFile(); ok {
+			// path is <root>/conf/<file>, so strip two levels.
+			projectRootPath = filepath.Dir(filepath.Dir(path))
+			return
+		}
+		projectRootPath, _ = os.Getwd()
+	})
+	return projectRootPath
+}
+
+// findConfigFile walks up from the working directory until one of
+// configCandidates exists, so it resolves both from the project root and from
+// any package directory during "go test".
+func findConfigFile() (string, bool) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", false
+	}
+	for {
+		for _, candidate := range configCandidates {
+			path := filepath.Join(dir, candidate)
+			if info, statErr := os.Stat(path); statErr == nil && !info.IsDir() {
+				return path, true
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
+}

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -1,0 +1,70 @@
+package bootstrap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/beego/beego/v2/core/config"
+)
+
+// TestConfigReadableFromPackageDirectory is the regression test for the panic
+// this package exists to prevent. "go test" runs with the working directory
+// set to this package directory, which is exactly the situation where beego's
+// relative "conf/app.conf" lookup fails.
+func TestConfigReadableFromPackageDirectory(t *testing.T) {
+	appname, err := config.String("appname")
+	if err != nil {
+		t.Fatalf("read appname from global config: %v", err)
+	}
+	if appname == "" {
+		t.Fatal("appname is empty, the global config instance was not loaded")
+	}
+}
+
+func TestProjectRootContainsConfDirectory(t *testing.T) {
+	root := ProjectRoot()
+	if root == "" {
+		t.Fatal("ProjectRoot returned an empty path")
+	}
+	info, err := os.Stat(filepath.Join(root, "conf"))
+	if err != nil {
+		t.Fatalf("conf directory not found under project root %q: %v", root, err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("%q is not a directory", filepath.Join(root, "conf"))
+	}
+}
+
+func TestFindConfigFileWalksUpFromWorkingDirectory(t *testing.T) {
+	path, ok := findConfigFile()
+	if !ok {
+		t.Fatal("findConfigFile did not locate a config file")
+	}
+	if !filepath.IsAbs(path) {
+		t.Fatalf("expected an absolute path, got %q", path)
+	}
+	base := filepath.Base(path)
+	if base != "app.conf" && base != "app.conf.example" {
+		t.Fatalf("unexpected config file %q", base)
+	}
+}
+
+func TestFindConfigFileReturnsFalseOutsideProject(t *testing.T) {
+	dir := t.TempDir()
+	original, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(original); err != nil {
+			t.Fatalf("restore working directory: %v", err)
+		}
+	})
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir to temp dir: %v", err)
+	}
+	if path, ok := findConfigFile(); ok {
+		t.Fatalf("expected no config file outside the project, got %q", path)
+	}
+}

--- a/controllers/login.go
+++ b/controllers/login.go
@@ -4,6 +4,9 @@ import (
 	"go_binance_futures/utils"
 	"strconv"
 
+	// Loads the global config before the package-level reads below run.
+	_ "go_binance_futures/bootstrap"
+
 	"github.com/beego/beego/v2/core/config"
 	"github.com/beego/beego/v2/server/web"
 )

--- a/feature/api/binance/index.go
+++ b/feature/api/binance/index.go
@@ -13,6 +13,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	// Loads the global config before the package-level reads below run.
+	_ "go_binance_futures/bootstrap"
+
 	"github.com/adshao/go-binance/v2/delivery"
 	"github.com/adshao/go-binance/v2/futures"
 	"github.com/beego/beego/v2/adapter/logs"

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -16,6 +16,9 @@ import (
 	"strings"
 	"time"
 
+	// Loads the global config before the package-level reads below run.
+	_ "go_binance_futures/bootstrap"
+
 	"github.com/adshao/go-binance/v2/futures"
 	"github.com/beego/beego/v2/client/orm"
 	"github.com/beego/beego/v2/core/config"

--- a/lang/utils.go
+++ b/lang/utils.go
@@ -3,8 +3,10 @@ package lang
 import (
 	"encoding/json"
 	"fmt"
+	"go_binance_futures/bootstrap"
 	"io"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -23,7 +25,9 @@ func ReadLangJsonFile(filePath string) (langTextMap map[string]interface{}, err 
 	if filePath == "" {
 		lang := GetLanguage()
 		logs.Info("use lang:", lang)
-		filePath = fmt.Sprintf("./lang/config/%s.json", lang)
+		// Resolve from the project root so the lookup also works when the
+		// process starts in a package directory, e.g. during "go test".
+		filePath = filepath.Join(bootstrap.ProjectRoot(), "lang", "config", lang+".json")
 	}
 	jsonFile, err := os.Open(filePath)
     if err != nil {

--- a/main.go
+++ b/main.go
@@ -16,6 +16,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	// Loads the global config before the package-level reads below run.
+	_ "go_binance_futures/bootstrap"
+
 	"github.com/beego/beego/v2/client/orm"
 	"github.com/beego/beego/v2/core/config"
 	"github.com/beego/beego/v2/core/logs"

--- a/middlewares/auth.go
+++ b/middlewares/auth.go
@@ -5,6 +5,9 @@ import (
 	"net/http"
 	"strings"
 
+	// Loads the global config before the package-level reads below run.
+	_ "go_binance_futures/bootstrap"
+
 	"github.com/beego/beego/v2/core/config"
 	"github.com/beego/beego/v2/server/web/context"
 	"github.com/golang-jwt/jwt/v5"

--- a/notify/dingding.go
+++ b/notify/dingding.go
@@ -9,6 +9,9 @@ import (
 	"io"
 	"net/http"
 
+	// Loads the global config before the package-level reads below run.
+	_ "go_binance_futures/bootstrap"
+
 	"github.com/beego/beego/v2/core/config"
 	"github.com/beego/beego/v2/core/logs"
 )

--- a/spot/api/binance/index.go
+++ b/spot/api/binance/index.go
@@ -8,6 +8,9 @@ import (
 	"strconv"
 	"time"
 
+	// Loads the global config before the package-level reads below run.
+	_ "go_binance_futures/bootstrap"
+
 	"github.com/adshao/go-binance/v2"
 	"github.com/beego/beego/v2/adapter/logs"
 	"github.com/beego/beego/v2/client/orm"

--- a/tests/default_test.go
+++ b/tests/default_test.go
@@ -3,11 +3,10 @@ package test
 import (
 	"net/http"
 	"net/http/httptest"
-	"testing"
-	"runtime"
 	"path/filepath"
-
-    "github.com/beego/beego/v2/core/logs"
+	"runtime"
+	"strings"
+	"testing"
 
 	_ "go_binance_futures/routers"
 
@@ -17,26 +16,57 @@ import (
 
 func init() {
 	_, file, _, _ := runtime.Caller(0)
-	apppath, _ := filepath.Abs(filepath.Dir(filepath.Join(file, ".." + string(filepath.Separator))))
+	apppath, _ := filepath.Abs(filepath.Dir(filepath.Join(file, ".."+string(filepath.Separator))))
 	beego.TestBeegoInit(apppath)
+	// The login controller binds the request body, which beego only retains
+	// when this option is on. main.go sets the same flag at startup.
+	beego.BConfig.CopyRequestBody = true
 }
 
+// TestLoginRejectsWrongCredentials is a smoke test for the router wiring, the
+// login controller and the configuration reads it depends on. It deliberately
+// avoids the database and the Binance API so it can run anywhere.
+//
+// It replaces the generated scaffold test that requested "/", a route this
+// project never registers, and therefore always failed with 404.
+func TestLoginRejectsWrongCredentials(t *testing.T) {
+	body := strings.NewReader(`{"username":"nobody","password":"definitely-wrong"}`)
+	request, err := http.NewRequest(http.MethodPost, "/login", body)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
 
-// TestBeego is a sample to run an endpoint test
-func TestBeego(t *testing.T) {
-	r, _ := http.NewRequest("GET", "/", nil)
-	w := httptest.NewRecorder()
-	beego.BeeApp.Handlers.ServeHTTP(w, r)
+	recorder := httptest.NewRecorder()
+	beego.BeeApp.Handlers.ServeHTTP(recorder, request)
 
-	logs.Trace("testing", "TestBeego", "Code[%d]\n%s", w.Code, w.Body.String())
-
-	Convey("Subject: Test Station Endpoint\n", t, func() {
-	        Convey("Status Code Should Be 200", func() {
-	                So(w.Code, ShouldEqual, 200)
-	        })
-	        Convey("The Result Should Not Be Empty", func() {
-	                So(w.Body.Len(), ShouldBeGreaterThan, 0)
-	        })
+	Convey("Subject: Login endpoint rejects wrong credentials\n", t, func() {
+		Convey("Status Code Should Be 200", func() {
+			So(recorder.Code, ShouldEqual, http.StatusOK)
+		})
+		Convey("The Result Should Not Be Empty", func() {
+			So(recorder.Body.Len(), ShouldBeGreaterThan, 0)
+		})
+		Convey("The Payload Should Carry The Credential Error Code", func() {
+			So(recorder.Body.String(), ShouldContainSubstring, `"code":101`)
+		})
 	})
 }
 
+// TestUnknownRouteReturnsNotFound pins down that the router does not expose a
+// catch-all handler, so a typo in a path fails loudly instead of being served.
+func TestUnknownRouteReturnsNotFound(t *testing.T) {
+	request, err := http.NewRequest(http.MethodGet, "/no-such-route", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	beego.BeeApp.Handlers.ServeHTTP(recorder, request)
+
+	Convey("Subject: Unknown route\n", t, func() {
+		Convey("Status Code Should Be 404", func() {
+			So(recorder.Code, ShouldEqual, http.StatusNotFound)
+		})
+	})
+}

--- a/utils/index.go
+++ b/utils/index.go
@@ -6,6 +6,9 @@ import (
 	"strconv"
 	"strings"
 
+	// Loads the global config before the package-level reads below run.
+	_ "go_binance_futures/bootstrap"
+
 	"github.com/beego/beego/v2/core/config"
 )
 


### PR DESCRIPTION
Fix config loading so `go test ./...` can run

## 问题

`core/config` 在 beego 自己的 init 里执行 `InitGlobalInstance("ini", "conf/app.conf")`，
这是**相对当前工作目录**的路径。`go test` 会在每个包自己的目录下启动测试二进制，找不到
文件时 `NewConfig` 返回一个装着 nil 指针的非空接口，之后任何 `config.String()` 都会解
引用 nil。

崩溃发生在包初始化阶段，比 `TestMain` 更早，所以在测试代码里无法规避。

在当前 master 上复现：

```
$ go test ./...
FAIL    go_binance_futures/feature/api/binance  0.051s
FAIL    go_binance_futures/middlewares          0.021s
FAIL    go_binance_futures/tests                0.025s

panic: runtime error: invalid memory address or nil pointer dereference
  github.com/beego/beego/v2/core/config.(*IniConfigContainer).getdata(...)
  go_binance_futures/lang.GetLanguage()
      lang/utils.go:18
```

影响是 `feature/api/binance`、`middlewares`、`tests` 三个包无法运行测试，其中第一个是
交易逻辑的核心包。

## 改法

新增 `bootstrap` 包，在 init 中从工作目录逐级向上查找 `conf/app.conf`，找到后重新加载
全局实例。找不到 `app.conf` 时回退 `conf/app.conf.example`——因为 `app.conf` 在
`.gitignore` 中，CI 和新克隆的仓库里不存在该文件，有回退才能开箱跑测试。

然后在读取配置的包中 blank import 它。其中一部分能通过传递依赖覆盖，但 init 顺序的隐式
依赖很脆弱：删掉一个看似无关的 import 就会重新崩溃，且报错位置离原因很远。所以显式声明，
这也是 Go 处理 init 副作用的惯用做法。

顺带修了 `lang` 包：它用 `./lang/config/%s.json` 读语言文件，同样的工作目录问题，改为
基于 `bootstrap.ProjectRoot()` 解析。

`tests/default_test.go` 修掉 panic 后暴露第二个问题：它是脚手架生成后未改过的模板，断言
`GET /` 返回 200，但 `routers/router.go` 没有注册根路由，所以一直是 404。改成测真实存在
的行为——`POST /login` 用错误凭据应返回 `code:101`，以及未知路由返回 404。选 login 是因为
它只依赖 config，不碰数据库和币安 API，任何环境都能跑。

## 验证

```
$ go build ./...
$ go test ./...
ok      go_binance_futures/bootstrap
ok      go_binance_futures/feature/api/binance
ok      go_binance_futures/mcpserver
ok      go_binance_futures/middlewares
ok      go_binance_futures/models
ok      go_binance_futures/scanner
ok      go_binance_futures/tests
```

在有 `conf/app.conf` 和只有 `conf/app.conf.example` 两种情况下都验证过。
`bootstrap` 包自带 4 个测试，其中 `TestConfigReadableFromPackageDirectory` 就是这个
bug 的回归测试——它在包目录下运行，正是原来会 panic 的场景。
