### PR TITLE
修复 MySQL 专有 SQL 导致 sqlite 模式无法启动

### DIFF
--- a/command/sql/version/1.sql
+++ b/command/sql/version/1.sql
@@ -1,2 +1,4 @@
-ALTER TABLE `symbols` ADD CONSTRAINT `uk_symbols_symbol` UNIQUE (`symbol`);
-ALTER TABLE `spot_symbols` ADD CONSTRAINT `uk_spot_symbols_symbol` UNIQUE (`symbol`);
+-- Use CREATE UNIQUE INDEX instead of ALTER TABLE ADD CONSTRAINT,
+-- because SQLite does not support adding constraints to an existing table.
+CREATE UNIQUE INDEX `uk_symbols_symbol` ON `symbols` (`symbol`);
+CREATE UNIQUE INDEX `uk_spot_symbols_symbol` ON `spot_symbols` (`symbol`);

--- a/feature/api/binance/index.go
+++ b/feature/api/binance/index.go
@@ -647,23 +647,49 @@ func buildBatchUpdateSymbolsSQL(tickers []futures.WsMarketTickerEvent) (string, 
 		"INSERT INTO `symbols` "+
 			"(`symbol`, `percentChange`, `close`, `open`, `low`, `high`, `enable`, `updateTime`, `lastClose`, `lastUpdateTime`, `baseVolume`, `quoteVolume`, `closeQty`, `tradeCount`, `leverage`, `marginType`, `tickSize`, `stepSize`, `usdt`, `profit`, `loss`, `kline_interval`, `technology`, `strategy`, `strategy_type`, `pin`, `sort`, `type`) "+
 			"VALUES %s "+
-			"ON DUPLICATE KEY UPDATE "+
-			"`lastClose` = `close`, "+
-			"`lastUpdateTime` = `updateTime`, "+
-			"`percentChange` = VALUES(`percentChange`), "+
-			"`close` = VALUES(`close`), "+
-			"`open` = VALUES(`open`), "+
-			"`low` = VALUES(`low`), "+
-			"`high` = VALUES(`high`), "+
-			"`updateTime` = VALUES(`updateTime`), "+
-			"`baseVolume` = VALUES(`baseVolume`), "+
-			"`quoteVolume` = VALUES(`quoteVolume`), "+
-			"`closeQty` = VALUES(`closeQty`), "+
-			"`tradeCount` = VALUES(`tradeCount`), "+
-			"`type` = VALUES(`type`)",
+			"%s",
 		strings.Join(valueParts, ", "),
+		batchUpdateSymbolsUpsertClause(),
 	)
 	return query, args
+}
+
+// batchUpdateSymbolsUpsertClause returns the driver specific upsert clause.
+// MySQL uses "ON DUPLICATE KEY UPDATE", while SQLite/Postgres use "ON CONFLICT ... DO UPDATE".
+func batchUpdateSymbolsUpsertClause() string {
+	driver, _ := config.String("database::driver")
+	if driver == "mysql" {
+		return "ON DUPLICATE KEY UPDATE " +
+			"`lastClose` = `close`, " +
+			"`lastUpdateTime` = `updateTime`, " +
+			"`percentChange` = VALUES(`percentChange`), " +
+			"`close` = VALUES(`close`), " +
+			"`open` = VALUES(`open`), " +
+			"`low` = VALUES(`low`), " +
+			"`high` = VALUES(`high`), " +
+			"`updateTime` = VALUES(`updateTime`), " +
+			"`baseVolume` = VALUES(`baseVolume`), " +
+			"`quoteVolume` = VALUES(`quoteVolume`), " +
+			"`closeQty` = VALUES(`closeQty`), " +
+			"`tradeCount` = VALUES(`tradeCount`), " +
+			"`type` = VALUES(`type`)"
+	}
+	// SQLite (default) syntax: unqualified columns on the right side refer to the existing row,
+	// "excluded" refers to the row proposed for insertion.
+	return "ON CONFLICT(`symbol`) DO UPDATE SET " +
+		"`lastClose` = `symbols`.`close`, " +
+		"`lastUpdateTime` = `symbols`.`updateTime`, " +
+		"`percentChange` = excluded.`percentChange`, " +
+		"`close` = excluded.`close`, " +
+		"`open` = excluded.`open`, " +
+		"`low` = excluded.`low`, " +
+		"`high` = excluded.`high`, " +
+		"`updateTime` = excluded.`updateTime`, " +
+		"`baseVolume` = excluded.`baseVolume`, " +
+		"`quoteVolume` = excluded.`quoteVolume`, " +
+		"`closeQty` = excluded.`closeQty`, " +
+		"`tradeCount` = excluded.`tradeCount`, " +
+		"`type` = excluded.`type`"
 }
 
 func UpdateCoinByWs(systemConfig *models.Config, retryNum int64) {

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -883,12 +883,25 @@ func buildBatchUpdateSymbolsTradePrecisionSQL(items []futuresSymbolPrecisionUpda
 		args = append(args, item.Symbol, item.TickSize, item.StepSize, item.Type)
 	}
 
-	query := fmt.Sprintf(
-		"UPDATE `symbols` AS s "+
-			"JOIN (%s) AS v ON s.symbol = v.symbol "+
-			"SET s.tickSize = v.tickSize, s.stepSize = v.stepSize, s.type = v.type",
-		strings.Join(selectParts, " UNION ALL "),
-	)
+	driver, _ := config.String("database::driver")
+	var query string
+	if driver == "mysql" {
+		query = fmt.Sprintf(
+			"UPDATE `symbols` AS s "+
+				"JOIN (%s) AS v ON s.symbol = v.symbol "+
+				"SET s.tickSize = v.tickSize, s.stepSize = v.stepSize, s.type = v.type",
+			strings.Join(selectParts, " UNION ALL "),
+		)
+	} else {
+		// SQLite (default) and Postgres do not support "UPDATE ... JOIN", they use "UPDATE ... FROM".
+		query = fmt.Sprintf(
+			"UPDATE `symbols` AS s "+
+				"SET tickSize = v.tickSize, stepSize = v.stepSize, type = v.type "+
+				"FROM (%s) AS v "+
+				"WHERE s.symbol = v.symbol",
+			strings.Join(selectParts, " UNION ALL "),
+		)
+	}
 
 	return query, args
 }


### PR DESCRIPTION
Fix raw SQL that only works on MySQL, sqlite mode cannot start

## 问题

README 说明支持 sqlite / mysql / postgres 三种驱动，但有三处裸写的 MySQL 专有语法，
导致 sqlite 模式不可用。

**1. `command/sql/version/1.sql` —— 进程无法启动**

```sql
ALTER TABLE `symbols` ADD CONSTRAINT `uk_symbols_symbol` UNIQUE (`symbol`);
```

sqlite 不支持给已存在的表添加约束。全新数据库首次启动时执行 v1 迁移直接 panic：

```
[E] !!! update database error !!!: update database version 1 failed:
    exec SQL error: near "CONSTRAINT": syntax error
panic: ...
  main.syncDb()  main.go:129
```

**2. `feature/api/binance/index.go` —— WebSocket 价格更新全部失败**

```go
"ON DUPLICATE KEY UPDATE " + ...
```

批量 upsert 每秒执行一次，每次都失败：

```
[E] futures ws batch update symbols error: near "DUPLICATE": syntax error
```

服务还活着，但 symbols 表的价格永远不更新，日志被刷屏。

**3. `feature/feature.go` —— 币种交易精度更新失败**

```go
"UPDATE `symbols` AS s JOIN (%s) AS v ON s.symbol = v.symbol SET ..."
```

sqlite 的 UPDATE 不支持 JOIN：

```
[E] update futures symbols trade precision error: near "JOIN": syntax error
```

## 改法

第一处改用 `CREATE UNIQUE INDEX`，mysql 与 sqlite 都接受，语义等价。

后两处按 `database::driver` 分支：mysql 保持原样，其他驱动分别用
`ON CONFLICT(symbol) DO UPDATE SET ... = excluded....` 和 `UPDATE ... FROM`。
sqlite 自 3.33 起支持 `UPDATE ... FROM`，`mattn/go-sqlite3 v1.14.22` 内置的版本满足要求。

在 `ON CONFLICT DO UPDATE` 中，未限定的列名指向已存在的行、`excluded` 指向待插入的行，
与 MySQL 里 `lastClose = close` 配合 `VALUES(...)` 的语义一致。

## 验证

在 sqlite 驱动下从零启动，迁移通过，737 个币种价格正常更新，日志零错误：

```
[I] use database driver: sqlite
[I] database does not exist, create and initialize
[I] @@@ update database success @@@
[I] futures websocket start: auto update symbols price
```

`go build ./...` 通过。mysql 分支的 SQL 未改动，行为不变。
