### PR TITLE
未授权的 API 请求返回 JSON，避免 token 过期后页面显示为空

### DIFF
--- a/middlewares/auth.go
+++ b/middlewares/auth.go
@@ -25,29 +25,64 @@ var excludeRoutes = []string{
 	"/" + webIndex,
 }
 
+// rejectUnauthorized answers a request that failed authentication.
+//
+// A browser navigating to a page should land back on the login screen, but an
+// XHR from the already loaded single page app needs a payload it can recognise.
+// Redirecting both meant an expired token made the API answer an HTML body with
+// status 401, which the frontend could not tell apart from an empty result, so
+// pages rendered as "no data" instead of prompting for login.
+func rejectUnauthorized(ctx *context.Context) {
+	if isPageRequest(ctx) {
+		ctx.Redirect(http.StatusUnauthorized, "/"+webIndex+"/index.html")
+		return
+	}
+	ctx.Output.SetStatus(http.StatusUnauthorized)
+	_ = ctx.Output.JSON(map[string]interface{}{
+		"code": http.StatusUnauthorized,
+		"msg":  "登录已过期或未登录",
+		"data": nil,
+	}, false, false)
+}
+
+// isPageRequest reports whether the caller is a browser asking for a document
+// rather than the app asking for data.
+func isPageRequest(ctx *context.Context) bool {
+	if strings.HasSuffix(ctx.Request.URL.Path, ".html") {
+		return true
+	}
+	if ctx.Request.Header.Get("X-Requested-With") == "XMLHttpRequest" {
+		return false
+	}
+	// Browsers ask for documents with an Accept that prefers text/html, while
+	// fetch and axios default to application/json or */*.
+	accept := ctx.Request.Header.Get("Accept")
+	return strings.Contains(accept, "text/html")
+}
+
 func JwtMiddleware(ctx *context.Context) {
-    request := ctx.Request
+	request := ctx.Request
 	path := ctx.Request.URL.Path
-	
+
 	// 跳过白名单
 	for _, excludeRoute := range excludeRoutes {
-        if match, _ := pathMatch(path, excludeRoute); match {
+		if match, _ := pathMatch(path, excludeRoute); match {
 			return
-        }
-    }
-	
-    // 获取请求头中的JWT Token
-    authHeader := request.Header.Get("Authorization")
-    if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer ") {
-		ctx.Redirect(http.StatusUnauthorized, "/" + webIndex + "/index.html")
+		}
+	}
+
+	// 获取请求头中的JWT Token
+	authHeader := request.Header.Get("Authorization")
+	if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer ") {
+		rejectUnauthorized(ctx)
 		return
-    }
+	}
 
 	claims, err := ValidateAuthorization(authHeader)
 	if err != nil {
-        ctx.Redirect(http.StatusUnauthorized, "/" + webIndex + "/index.html")
-        return
-    }
+		rejectUnauthorized(ctx)
+		return
+	}
 	ctx.Input.SetData("user", claims)
 }
 

--- a/middlewares/auth_unauthorized_test.go
+++ b/middlewares/auth_unauthorized_test.go
@@ -1,0 +1,127 @@
+package middlewares
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/beego/beego/v2/server/web/context"
+)
+
+func newRequestContext(path string, headers map[string]string) (*context.Context, *httptest.ResponseRecorder) {
+	request := httptest.NewRequest(http.MethodGet, path, nil)
+	for key, value := range headers {
+		request.Header.Set(key, value)
+	}
+	recorder := httptest.NewRecorder()
+	ctx := context.NewContext()
+	ctx.Reset(recorder, request)
+	return ctx, recorder
+}
+
+// An expired token used to make every API call answer 401 with an HTML body,
+// which the frontend could not distinguish from an empty result, so pages
+// rendered as "no data" rather than prompting for login.
+func TestUnauthorizedApiRequestGetsJson(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		headers map[string]string
+	}{
+		{
+			name:    "axios style request",
+			path:    "/test-strategy-results",
+			headers: map[string]string{"Accept": "application/json, text/plain, */*"},
+		},
+		{
+			name:    "explicit xhr marker",
+			path:    "/features",
+			headers: map[string]string{"X-Requested-With": "XMLHttpRequest", "Accept": "text/html"},
+		},
+		{
+			name:    "no accept header at all",
+			path:    "/config",
+			headers: nil,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx, recorder := newRequestContext(testCase.path, testCase.headers)
+			JwtMiddleware(ctx)
+
+			if recorder.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
+			}
+			if location := recorder.Header().Get("Location"); location != "" {
+				t.Fatalf("api request should not be redirected, got Location %q", location)
+			}
+			var payload struct {
+				Code int    `json:"code"`
+				Msg  string `json:"msg"`
+			}
+			if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+				t.Fatalf("body is not json: %v, body=%q", err, recorder.Body.String())
+			}
+			if payload.Code != http.StatusUnauthorized {
+				t.Fatalf("payload code = %d, want %d", payload.Code, http.StatusUnauthorized)
+			}
+			if payload.Msg == "" {
+				t.Fatal("payload should carry a message the frontend can surface")
+			}
+		})
+	}
+}
+
+func TestUnauthorizedPageRequestRedirects(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		headers map[string]string
+	}{
+		{
+			name:    "browser navigation",
+			path:    "/orders",
+			headers: map[string]string{"Accept": "text/html,application/xhtml+xml"},
+		},
+		{
+			name:    "html document path",
+			path:    "/somewhere/page.html",
+			headers: nil,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx, recorder := newRequestContext(testCase.path, testCase.headers)
+			JwtMiddleware(ctx)
+
+			if recorder.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
+			}
+			location := recorder.Header().Get("Location")
+			if !strings.HasSuffix(location, "/index.html") {
+				t.Fatalf("Location = %q, want it to point at the login page", location)
+			}
+		})
+	}
+}
+
+// The excluded routes must stay reachable without a token, otherwise login and
+// the notification websocket handshake break.
+func TestExcludedRoutesSkipAuth(t *testing.T) {
+	for _, path := range []string{"/login", "/ws/notifications"} {
+		t.Run(path, func(t *testing.T) {
+			ctx, recorder := newRequestContext(path, nil)
+			JwtMiddleware(ctx)
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("status = %d, want the request to pass through untouched", recorder.Code)
+			}
+			if recorder.Body.Len() != 0 {
+				t.Fatalf("middleware should not write a body, got %q", recorder.Body.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Return JSON for unauthorized API requests, expired token makes pages look empty

> 依赖 #29（已合并，本 PR 已 rebase 到其之后）。新增的测试位于 `middlewares` 包，而该包在当前
> master 上因为配置加载问题无法初始化，测试跑不起来。前一个 PR 合并后本 PR 的测试才能
> 实际运行。

## 问题

`JwtMiddleware` 对所有未通过鉴权的请求一律 `ctx.Redirect`，返回 401 状态加一段 HTML：

```go
ctx.Redirect(http.StatusUnauthorized, "/" + webIndex + "/index.html")
```

前端是只解析 JSON 的 SPA。token 按 `web::expires` 过期后（默认 24 小时），所有列表接口
返回的都是它读不懂的 HTML，于是页面渲染成空列表，**而不是跳转登录页**。

复现：

```
$ curl -s -D - http://127.0.0.1:7414/test-strategy-results \
    -H "Accept: application/json, text/plain, */*"
HTTP/1.1 401 Unauthorized
Location: /zmkm/index.html

<a href="/zmkm/index.html">Unauthorized</a>.
```

这个缺陷的隐蔽性在于它不报错、不留日志，只是让人误判数据丢失。我这边是「测试结果」页
显示为空，一度以为 168 条模拟交易记录被清了，实际全部完好，只是 token 过期。

## 改法

按请求类型区分：浏览器请求文档（`Accept` 偏好 `text/html`，或路径以 `.html` 结尾）仍
重定向到登录页；其余请求返回 `{"code":401,"msg":"...","data":null}`，前端的通用错误
处理可以识别并跳转。

白名单逻辑未改动。`/ws/notifications` 仍在其中——它的鉴权走 query 参数 `token` 而非
请求头，由控制器自行校验。

## 验证

```
API 请求   → 401, Content-Type: application/json, {"code":401,...}, 无 Location
页面请求   → 401, Location: /zmkm/index.html
/login     → 未被拦截
/ws/notifications 带 token → 101 Switching Protocols
```

新增 8 个测试用例，覆盖 axios 风格请求、显式 `X-Requested-With` 标记、无 `Accept` 头、
浏览器导航、`.html` 路径，以及两个白名单路由必须仍能无 token 通过。
